### PR TITLE
loki: Show chunk compression as percent of the uncompressed size

### DIFF
--- a/charts/grafana-dashboard/dashboards/loki.json
+++ b/charts/grafana-dashboard/dashboards/loki.json
@@ -2231,10 +2231,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
+      "description": "Percent of the uncompressed size",
       "fieldConfig": {
         "defaults": {
           "custom": {},
-          "links": []
+          "links": [],
+          "unit": "percentunit"
         },
         "overrides": []
       },
@@ -2279,7 +2281,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(loki_ingester_chunk_compression_ratio_bucket[5m])) by (le))",
+          "expr": "1 / histogram_quantile(0.95, sum(rate(loki_ingester_chunk_compression_ratio_bucket[5m])) by (le))",
           "interval": "",
           "legendFormat": "ratio",
           "refId": "A"
@@ -2289,7 +2291,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Chunk Compression Ratios",
+      "title": "Chunk Compression",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2306,7 +2308,7 @@
       "yaxes": [
         {
           "$$hashKey": "object:155",
-          "format": "percent",
+          "format": "percentunit",
           "label": null,
           "logBase": 1,
           "max": null,

--- a/charts/grafana-dashboard/dashboards/loki.json
+++ b/charts/grafana-dashboard/dashboards/loki.json
@@ -2808,7 +2808,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Chunks in Streams",
+      "title": "Streams in memory",
       "tooltip": {
         "shared": true,
         "sort": 0,


### PR DESCRIPTION
Before it was shown as a ratio in percent, which didn't make any sense.
We could just show the raw value but I think showing it as percent of
the uncompressed size is more intuitive.